### PR TITLE
Scheduler methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.9
+    python: python3.10
 
 repos:
   - repo: https://github.com/PyCQA/isort

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -124,7 +124,7 @@ class DataParallelController:
         self.main_num_waiting_req = []
 
         # For pre_radix
-        self.zmq_raidx = server_args.load_balance_method == "pre_radix"
+        self.pre_raidx = server_args.load_balance_method == "pre_radix"
 
         # Start data parallel workers
         base_gpu_id = 0
@@ -140,7 +140,7 @@ class DataParallelController:
             self.workers.append(send_to)
             base_gpu_id += server_args.tp_size
 
-        if self.zmq_raidx:
+        if self.pre_raidx:
             import threading
 
             self.newest_tree_cache = {}
@@ -231,7 +231,7 @@ class DataParallelController:
         if not self.main_available_kv_cache:
             self.main_available_kv_cache = available_mem.copy()
         if self.pre_available_kv_cache != available_mem:
-            self.pre_available_kv_cache = available_mem.copy()
+            self.pre_available_kv_cache = available_mem
             self.main_available_kv_cache = available_mem.copy()
 
         if not self.pre_num_running_req:
@@ -239,7 +239,7 @@ class DataParallelController:
         if not self.main_num_running_req:
             self.main_num_running_req = num_reqs_running.copy()
         if self.pre_num_running_req != num_reqs_running:
-            self.main_num_running_req = num_reqs_running.copy()
+            self.main_num_running_req = num_reqs_running
             self.pre_num_running_req = num_reqs_running.copy()
 
         if not self.pre_num_waiting_req:
@@ -247,7 +247,7 @@ class DataParallelController:
         if not self.main_num_waiting_req:
             self.main_num_waiting_req = num_reqs_waiting.copy()
         if self.pre_num_waiting_req != num_reqs_waiting:
-            self.main_num_waiting_req = num_reqs_waiting.copy()
+            self.main_num_waiting_req = num_reqs_waiting
             self.pre_num_waiting_req = num_reqs_waiting.copy()
 
     def allocate_gpu(self, req):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -17,11 +17,13 @@ limitations under the License.
 
 import logging
 import multiprocessing as mp
+import multiprocessing.connection
 from enum import Enum, auto
 
 import zmq
 
 from sglang.srt.managers.io_struct import (
+    ControllerInfo,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     TokenizedRewardReqInput,
@@ -37,12 +39,42 @@ from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
 
+import random
+
+
+# for pre radix scheduler
+def _key_match(key0, key1):
+    i = 0
+    for k0, k1 in zip(key0, key1):
+        if k0 != k1:
+            break
+        i += 1
+    return i
+
+
+def get_match_len(node, key, match_length: int) -> int:
+    if len(key) == 0:
+        return match_length
+
+    if key[0] in node.children.keys():
+        child = node.children[key[0]]
+        prefix_len = _key_match(child.key, key)
+        match_length += prefix_len
+        if prefix_len < len(child.key):
+            return match_length
+        else:
+            return get_match_len(child, key[prefix_len:], match_length)
+    else:
+        return match_length
+
 
 class LoadBalanceMethod(Enum):
     """Load balance method."""
 
     ROUND_ROBIN = auto()
     SHORTEST_QUEUE = auto()
+    RESOURCES_AWARE = auto()
+    PRE_RADIX = auto()
 
     @classmethod
     def from_str(cls, method: str):
@@ -74,8 +106,28 @@ class DataParallelController:
         dispatch_lookup = {
             LoadBalanceMethod.ROUND_ROBIN: self.round_robin_scheduler,
             LoadBalanceMethod.SHORTEST_QUEUE: self.shortest_queue_scheduler,
+            LoadBalanceMethod.RESOURCES_AWARE: self.resources_aware_scheduler,
+            LoadBalanceMethod.PRE_RADIX: self.pre_radix_scheduler,
         }
         self.dispatching = dispatch_lookup[self.load_balance_method]
+
+        # For resources aware
+        self.dp_size = server_args.dp_size
+        self.controller_info = ControllerInfo(server_args.dp_size)
+        self.pre_available_kv_cache = []
+        self.main_available_kv_cache = []
+
+        self.pre_num_running_req = []
+        self.main_num_running_req = []
+
+        self.pre_num_waiting_req = []
+        self.main_num_waiting_req = []
+
+        # For pre_radix
+        self.choosen_gpu_per_req = {}
+
+        # For zmq_radix
+        self.zmq_raidx = server_args.load_balance_method == "zmq_radix"
 
         # Start data parallel workers
         base_gpu_id = 0
@@ -85,14 +137,24 @@ class DataParallelController:
             tmp_port_args.detokenizer_ipc_name = port_args.detokenizer_ipc_name
 
             send_to = self.launch_tensor_parallel_group(
-                server_args,
-                tmp_port_args,
-                base_gpu_id,
-                dp_rank,
+                server_args, tmp_port_args, base_gpu_id, dp_rank, self.controller_info
             )
 
             self.workers.append(send_to)
             base_gpu_id += server_args.tp_size
+
+        if self.zmq_raidx:
+            import threading
+
+            self.newest_tree_cache = {}
+
+            self.recv_tree_cache_lock = threading.Lock()
+            self.recv_tree_cache_thread = threading.Thread(
+                target=self.loop_for_recv_tree_cache
+            )
+        else:
+            self.newest_tree_cache = None
+            self.recv_tree_cache_thread = None
 
     def launch_tensor_parallel_group(
         self,
@@ -100,6 +162,7 @@ class DataParallelController:
         port_args: PortArgs,
         base_gpu_id: int,
         dp_rank: int,
+        controller_info: ControllerInfo,
     ):
         # Launch tensor parallel scheduler processes
         scheduler_procs = []
@@ -114,7 +177,15 @@ class DataParallelController:
             gpu_id = base_gpu_id + tp_rank % tp_size_per_node
             proc = mp.Process(
                 target=run_scheduler_process,
-                args=(server_args, port_args, gpu_id, tp_rank, dp_rank, writer),
+                args=(
+                    server_args,
+                    port_args,
+                    gpu_id,
+                    tp_rank,
+                    dp_rank,
+                    writer,
+                    controller_info,
+                ),
             )
             proc.start()
             scheduler_procs.append(proc)
@@ -129,9 +200,107 @@ class DataParallelController:
 
         return send_to
 
+    def loop_for_recv_tree_cache(self):
+        while True:
+            self.recv_tree_cache()
+
+    def recv_tree_cache(self):
+        while True:
+            recv_radix_cache = self.controller_info.radix_queue.get()
+            if recv_radix_cache:
+                # logger.info('[recv_tree_cache] receive new data')
+                gpu_id = recv_radix_cache.gpu_id
+                if (
+                    gpu_id not in self.newest_tree_cache
+                    or recv_radix_cache.time > self.newest_tree_cache[gpu_id].time
+                ):
+                    with self.recv_tree_cache_lock:
+                        if gpu_id in self.newest_tree_cache:
+                            del self.newest_tree_cache[gpu_id]
+                        self.newest_tree_cache[gpu_id] = recv_radix_cache
+                del recv_radix_cache
+
     def round_robin_scheduler(self, req):
         self.workers[self.round_robin_counter].send_pyobj(req)
         self.round_robin_counter = (self.round_robin_counter + 1) % len(self.workers)
+
+    def update_memory_and_requests(self):
+        available_mem = [k.value for k in self.controller_info.available_kv_cache]
+        num_reqs_running = [k.value for k in self.controller_info.running_reqs]
+        num_reqs_waiting = [k.value for k in self.controller_info.waiting_reqs]
+
+        if not self.pre_available_kv_cache:
+            self.pre_available_kv_cache = available_mem.copy()
+        if not self.main_available_kv_cache:
+            self.main_available_kv_cache = available_mem.copy()
+        if self.pre_available_kv_cache != available_mem:
+            self.pre_available_kv_cache = available_mem.copy()
+            self.main_available_kv_cache = available_mem.copy()
+
+        if not self.pre_num_running_req:
+            self.pre_num_running_req = num_reqs_running.copy()
+        if not self.main_num_running_req:
+            self.main_num_running_req = num_reqs_running.copy()
+        if self.pre_num_running_req != num_reqs_running:
+            self.main_num_running_req = num_reqs_running.copy()
+            self.pre_num_running_req = num_reqs_running.copy()
+
+        if not self.pre_num_waiting_req:
+            self.pre_num_waiting_req = num_reqs_waiting.copy()
+        if not self.main_num_waiting_req:
+            self.main_num_waiting_req = num_reqs_waiting.copy()
+        if self.pre_num_waiting_req != num_reqs_waiting:
+            self.main_num_waiting_req = num_reqs_waiting.copy()
+            self.pre_num_waiting_req = num_reqs_waiting.copy()
+
+    def allocate_gpu(self, req):
+        all_waiting = min(self.main_num_waiting_req) > 0
+        no_waiting = [1 if waiting == 0 else 0 for waiting in self.main_num_waiting_req]
+
+        if all_waiting:
+            ratio = [
+                run / wait
+                for run, wait in zip(
+                    self.main_num_running_req, self.main_num_waiting_req
+                )
+            ]
+            max_ratio = max(ratio)
+            indices = [i for i, x in enumerate(ratio) if x == max_ratio]
+            gpu_idx = random.choice(indices)
+        else:
+            filter_result = [
+                a * b for a, b in zip(no_waiting, self.main_available_kv_cache)
+            ]
+            max_value = max(filter_result)
+            max_indices = [
+                index for index, value in enumerate(filter_result) if value == max_value
+            ]
+            gpu_idx = random.choice(max_indices)
+
+        self.main_num_waiting_req[gpu_idx] += 1
+        self.main_available_kv_cache[gpu_idx] -= len(req.input_ids)
+        return gpu_idx
+
+    def resources_aware_scheduler(self, req):
+        self.update_memory_and_requests()
+        gpu_idx = self.allocate_gpu(req)
+        self.workers[gpu_idx].send_pyobj(req)
+
+    def pre_radix_scheduler(self, req):
+        prefix_lens = [0] * self.dp_size
+
+        with self.recv_tree_cache_lock:
+            for gpu_id, radix_cache in self.newest_tree_cache.items():
+                pre_len = get_match_len(radix_cache.root_node, req.input_ids, 0)
+                prefix_lens[gpu_id] = pre_len
+
+            # NOTE: 100 is used to reduce the influence of random input
+            # e.g. If the match nums is [1, 2, 0, 0, 0, 0], we think the scheduer method should be resources aware
+            if max(prefix_lens) <= 100:
+                self.resources_aware_scheduler(req)
+            else:
+                gpu_idx = prefix_lens.index(max(prefix_lens))
+                self.workers[gpu_idx].send_pyobj(req)
 
     def shortest_queue_scheduler(self, input_requests):
         raise NotImplementedError()
@@ -144,6 +313,7 @@ class DataParallelController:
                 except zmq.ZMQError:
                     break
 
+                # logger.info(f"[event_loop]{type(recv_req)}")
                 if isinstance(
                     recv_req,
                     (
@@ -170,6 +340,8 @@ def run_data_parallel_controller_process(
     try:
         controller = DataParallelController(server_args, port_args)
         pipe_writer.send("ready")
+        if controller.recv_tree_cache_thread:
+            controller.recv_tree_cache_thread.start()
         controller.event_loop()
     except Exception:
         msg = get_exception_traceback()

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -124,10 +124,7 @@ class DataParallelController:
         self.main_num_waiting_req = []
 
         # For pre_radix
-        self.choosen_gpu_per_req = {}
-
-        # For zmq_radix
-        self.zmq_raidx = server_args.load_balance_method == "zmq_radix"
+        self.zmq_raidx = server_args.load_balance_method == "pre_radix"
 
         # Start data parallel workers
         base_gpu_id = 0

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -18,9 +18,11 @@ The definition of objects transfered between different
 processes (TokenizerManager, DetokenizerManager, Controller).
 """
 
+import multiprocessing
 import uuid
 from dataclasses import dataclass
 from enum import Enum
+from multiprocessing import Value
 from typing import Dict, List, Optional, Union
 
 from sglang.srt.managers.schedule_batch import BaseFinishReason
@@ -353,3 +355,19 @@ class AbortReq:
 class ProfileReq(Enum):
     START_PROFILE = 1
     STOP_PROFILE = 2
+
+
+class ControllerInfo:
+    def __init__(self, dp_size):
+        self.available_kv_cache = []
+        self.running_reqs = []
+        self.waiting_reqs = []
+        self.lock = multiprocessing.Lock()
+
+        # For pre radix
+        self.radix_queue = multiprocessing.Queue()
+
+        for i in range(dp_size):
+            self.available_kv_cache.append(Value("i", 0))
+            self.running_reqs.append(Value("i", 0))
+            self.waiting_reqs.append(Value("i", 0))

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -276,7 +276,7 @@ class Scheduler:
             self.controller_info.available_kv_cache[self.gpu_id].value = (
                 self.token_to_kv_pool.available_size()
             )
-            if self.server_args.load_balance_method == "zmq_radix":
+            if self.server_args.load_balance_method == "pre_radix":
                 self.pre_radix = True
                 import threading
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -22,6 +22,7 @@ The radix tree data structure for managing the KV cache.
 import heapq
 import time
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
@@ -31,6 +32,13 @@ from sglang.srt.mem_cache.memory_pool import BaseTokenToKVPool, ReqToTokenPool
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
+
+
+@dataclass
+class RadixCacheSend:
+    gpu_id: int
+    root_node: TreeNode
+    time: time
 
 
 class TreeNode:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -444,9 +444,10 @@ class ServerArgs:
             choices=[
                 "round_robin",
                 "shortest_queue",
+                "resources_aware",
+                "pre_radix",
             ],
         )
-
         # Multi-node distributed serving args
         parser.add_argument(
             "--dist-init-addr",


### PR DESCRIPTION
We have added two new load balancing solutions, **resources_aware** and **pre_radix**

## resources_aware
**resources_aware** takes into account the GPU resource usage to dynamically schedule requests. The comparison results of resources_aware are shown in the figure.

![image](https://github.com/user-attachments/assets/5c07f1ef-6e46-47fb-9e53-062b4816672c)

The script and environment that produces the result is as follows:
serving:
`/workspace/bin/micromamba run -n sglang python3 -m sglang.launch_server  --model-path meta-llama/Meta-Llama-3.1-8B --host 127.0.0.1 --port 8080 --mem-fraction-static 0.7 --dp-size 8 --load-balance-method resources_aware`
bench:
`/workspace/bin/micromamba run -n sglang python3 -m sglang.bench_serving --backend sglang  --host 127.0.0.1 --port 8080 --dataset-name random --tokenizer meta-llama/Meta-Llama-3.1-8B --model meta-llama/Meta-Llama-3.1-8B --random-output-len 1024 --random-input-len 4096 --random-range-ratio 0.5 --seed 1234 --num-prompts 90000--request-rate 15.7`

## pre_radix
**pre_radix** is ​​implemented based on resources_aware. It can greatly improve the KV Cache hit rate. It is mainly used to handle multi-round dialogue situations. Its results are as follows:
![image](https://github.com/user-attachments/assets/3fd6d7c4-4d94-44a6-9642-747d112a5e06)


We also counted the cache hit rate during the inference process, and the results are as follows:
**round_robin cache hit rate**
![round_robin cache hit rate](https://github.com/user-attachments/assets/089ec0ae-b2fd-4d5b-a194-da069de16550)
**pre_radix cache hit rate**
![pre_radix cache hit rate](https://github.com/user-attachments/assets/99f5669a-85d4-438c-9df6-8dcc439fcf12)

The script and environment that produces the result is as follows:
`/workspace/bin/micromamba run -n sglang python3 -m sglang.launch_server --model-path Qwen/Qwen2-7B --host 127.0.0.1 --port 8080 --mem-fraction-static 0.7 --dp-size 8 --load-balance-method pre_radix`

`/workspace/bin/micromamba run -n sglang python3 /workspace/sglang/benchmark/multi_turn_chat/bench_sglang.py --tokenizer Qwen/Qwen2-7B --port 8080 --parallel 128 --min-len-q 128 --max-len-q 256  --min-len-a 256 --max-len-a 512 --turns 20 --num-qa 256`

btw, we modified the benchmark code to make the number of rounds of multi-round dialogue a random value to enhance the persuasiveness of our experimental results.